### PR TITLE
Remove lintr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ LazyData: true
 Depends:
   uuid,
   methods,
-  lintr,
   stats
 Imports:
     uuid,
@@ -22,5 +21,6 @@ Imports:
     logging,
     pryr
 Suggests:
-    testthat
+    testthat,
+    lintr
 RoxygenNote: 5.0.1


### PR DESCRIPTION
This is a pretty giant package which requires many other packages to be
installed - we should really only optionally use it for development.